### PR TITLE
change method name getInstance to inject, now inject the client insted of return the getInstance

### DIFF
--- a/lib/active-client.js
+++ b/lib/active-client.js
@@ -13,13 +13,13 @@ class ActiveClient {
 		const client = clients && clients.length === 1 ? clients[0] : false;
 
 		if(client)
-			client.getInstance = this.getInstance(client);
+			this.inject(client);
 
 		return client;
 	}
 
-	static getInstance(client) {
-		return TheClass => {
+	static inject(client) {
+		client.getInstance = TheClass => {
 			const instance = new TheClass();
 			instance.client = client;
 


### PR DESCRIPTION
Se modifico la asignación de la instancia del cliente, ahora en vez de devolver una instancia  para luego asignársela al cliente, se inyecta el mismo con la asignación de la instancia. Esto sirve para sacarle un mejor provecho al package de api-test